### PR TITLE
pytest cleanup

### DIFF
--- a/python/tests/cassettes/test_nessie_cli/test_assign.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_assign.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,11 +130,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_assign", "snapshotId": 42, "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents": null, "key": {"elements":
-      ["assign", "foo", "bar"]}, "type": "PUT"}], "commitMeta": {"authorTime": null,
-      "properties": null, "committer": null, "message": "test message", "hash": null,
-      "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_assign", "type": "ICEBERG_TABLE"}, "key":
+      {"elements": ["assign", "foo", "bar"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -152,7 +152,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -176,7 +176,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -186,8 +186,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e",
-      "name": "main", "type": "BRANCH"}'
+    body: '{"name": "main", "hash": "44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -240,8 +240,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -280,8 +280,8 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}
+        \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}
         ]"
     headers:
       Content-Length:
@@ -306,7 +306,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -316,8 +316,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e",
-      "name": "v1.0", "type": "TAG"}'
+    body: '{"name": "v1.0", "hash": "44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -335,7 +335,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -360,9 +360,9 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}
+        \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}
         ]"
     headers:
       Content-Length:
@@ -387,7 +387,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -397,8 +397,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e",
-      "name": "v1.0", "type": "TAG"}'
+    body: '{"name": "v1.0", "hash": "44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -441,7 +441,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/v1.0
   response:
     body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
+      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}"
     headers:
       Content-Length:
       - '118'
@@ -451,8 +451,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e",
-      "name": "dev", "type": "TAG"}'
+    body: '{"name": "dev", "hash": "44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -467,7 +467,7 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: PUT
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e
+    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf
   response:
     body:
       string: ''
@@ -491,289 +491,13 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n},
-        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}
+        \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n},
+        {\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"44797605cd90b74312efc2d92a2f92110a18db4f37d924a16d728bfe5a2a94cf\"\n}
         ]"
     headers:
       Content-Length:
       - '367'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/v1.0
-  response:
-    body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
-    headers:
-      Content-Length:
-      - '118'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log
-  response:
-    body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.266760Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.266760Z\",\n    \"properties\"
-        : { }\n  } ]\n}"
-    headers:
-      Content-Length:
-      - '383'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/assign.foo.bar?ref=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_assign\",\n  \"metadataLocation\"
-        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
-    headers:
-      Content-Length:
-      - '108'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"operations": [{"key": {"elements": ["assign", "foo", "bar"]}, "type":
-      "DELETE"}], "commitMeta": {"authorTime": null, "properties": null, "committer":
-      null, "message": "delete_message", "hash": null, "author": null, "signedOffBy":
-      null, "commitTime": null}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '258'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=d1e4914f97e9b7872d62c292e080e2acf09a0b066652d303caa463f54681674e
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b3104c66ec738a17dc2deed76e4de7c24c061b35a2f044bd26940ca9e9f6b80c\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"b3104c66ec738a17dc2deed76e4de7c24c061b35a2f044bd26940ca9e9f6b80c\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=b3104c66ec738a17dc2deed76e4de7c24c061b35a2f044bd26940ca9e9f6b80c
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
       Content-Type:
       - application/json
     status:

--- a/python/tests/cassettes/test_nessie_cli/test_branch.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_branch.yaml
@@ -73,8 +73,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -153,8 +153,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "etl", "type": "BRANCH"}'
+    body: '{"name": "etl", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'

--- a/python/tests/cassettes/test_nessie_cli/test_commit_no_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_commit_no_expected_state.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,12 +130,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_commit_no_expected_state", "metadataLocationHistory":
-      ["asd111"], "lastCheckpoint": "x", "checkpointLocationHistory": ["def"], "type":
-      "DELTA_LAKE_TABLE"}, "expectedContents": null, "key": {"elements": ["commit",
-      "expected", "contents"]}, "type": "PUT"}], "commitMeta": {"authorTime": null,
-      "properties": null, "committer": null, "message": "commit 1", "hash": null,
-      "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "commit 1", "properties": null, "hash": null,
+      "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"checkpointLocationHistory":
+      ["def"], "lastCheckpoint": "x", "metadataLocationHistory": ["asd111"], "id":
+      "test_commit_no_expected_state", "type": "DELTA_LAKE_TABLE"}, "key": {"elements":
+      ["commit", "expected", "contents"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -153,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"94dcaac8ffc3f16b9f30b932abec068bee2926d57d1015eefb416bd081e5b629\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f816cb3779408155554efb1c461c4fbc2adb744af1001503cc1583afe752c467\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -179,7 +179,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"94dcaac8ffc3f16b9f30b932abec068bee2926d57d1015eefb416bd081e5b629\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"f816cb3779408155554efb1c461c4fbc2adb744af1001503cc1583afe752c467\"\n}
         ]"
     headers:
       Content-Length:
@@ -216,12 +216,12 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"contents": {"id": "test_commit_no_expected_state", "metadataLocationHistory":
-      ["asd222"], "lastCheckpoint": "x", "checkpointLocationHistory": ["def"], "type":
-      "DELTA_LAKE_TABLE"}, "expectedContents": null, "key": {"elements": ["commit",
-      "expected", "contents"]}, "type": "PUT"}], "commitMeta": {"authorTime": null,
-      "properties": null, "committer": null, "message": "commit 2", "hash": null,
-      "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "commit 2", "properties": null, "hash": null,
+      "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"checkpointLocationHistory":
+      ["def"], "lastCheckpoint": "x", "metadataLocationHistory": ["asd222"], "id":
+      "test_commit_no_expected_state", "type": "DELTA_LAKE_TABLE"}, "key": {"elements":
+      ["commit", "expected", "contents"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -236,10 +236,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=94dcaac8ffc3f16b9f30b932abec068bee2926d57d1015eefb416bd081e5b629
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=f816cb3779408155554efb1c461c4fbc2adb744af1001503cc1583afe752c467
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c6ea469d4a3a09689cca2e4101f748ea9de1a7a5c54131576d8b1133d8bb854b\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"e12a60d4342359ab7b542384bd6ae69c22efecb25920ed073fd1e11a7ee0edab\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -248,129 +248,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"c6ea469d4a3a09689cca2e4101f748ea9de1a7a5c54131576d8b1133d8bb854b\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=c6ea469d4a3a09689cca2e4101f748ea9de1a7a5c54131576d8b1133d8bb854b
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Named reference 'main' already exists.\",\n  \"status\"
-        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
-    headers:
-      Content-Length:
-      - '130'
-      Content-Type:
-      - application/json
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_commit_with_expected_state.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_commit_with_expected_state.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,12 +130,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_expected_contents", "snapshotId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents":
-      null, "key": {"elements": ["commit", "expected", "contents"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "properties": null, "committer": null, "message":
-      "commit 1", "hash": null, "author": "nessie test", "signedOffBy": null, "commitTime":
-      null}}'
+    body: '{"commitMeta": {"message": "commit 1", "properties": null, "hash": null,
+      "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_expected_contents", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["commit", "expected", "contents"]}, "expectedContents":
+      null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -153,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"b2aafcc0ae1d5a6c189d4a0dc5def5773ee9025fc4fe91141b63b3cc0cd8919a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"7e810fa6fbb65ba81086ead428ed79a08ffa387eed8c74235fa20b4043566def\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -179,7 +179,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"b2aafcc0ae1d5a6c189d4a0dc5def5773ee9025fc4fe91141b63b3cc0cd8919a\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"7e810fa6fbb65ba81086ead428ed79a08ffa387eed8c74235fa20b4043566def\"\n}
         ]"
     headers:
       Content-Length:
@@ -215,13 +215,13 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"contents": {"id": "test_expected_contents", "snapshotId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents":
-      {"id": "test_expected_contents", "snapshotId": 42, "metadataLocation": "/a/b/c",
-      "type": "ICEBERG_TABLE"}, "key": {"elements": ["commit", "expected", "contents"]},
-      "type": "PUT"}], "commitMeta": {"authorTime": null, "properties": null, "committer":
-      null, "message": "commit 2", "hash": null, "author": "nessie test", "signedOffBy":
-      null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "commit 2", "properties": null, "hash": null,
+      "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_expected_contents", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["commit", "expected", "contents"]}, "expectedContents":
+      {"metadataLocation": "/a/b/c", "snapshotId": 42, "id": "test_expected_contents",
+      "type": "ICEBERG_TABLE"}, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -236,10 +236,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=b2aafcc0ae1d5a6c189d4a0dc5def5773ee9025fc4fe91141b63b3cc0cd8919a
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=7e810fa6fbb65ba81086ead428ed79a08ffa387eed8c74235fa20b4043566def
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"03f7b02fb8d1ba2913087d3aae965c7cb0da3b52cffa154ec674e36b86b7139c\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"6aca3ec67144f52520292342b1cdaf1e2a30204e4331478819cb8c1644b414f1\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -248,129 +248,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"03f7b02fb8d1ba2913087d3aae965c7cb0da3b52cffa154ec674e36b86b7139c\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=03f7b02fb8d1ba2913087d3aae965c7cb0da3b52cffa154ec674e36b86b7139c
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Named reference 'main' already exists.\",\n  \"status\"
-        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
-    headers:
-      Content-Length:
-      - '130'
-      Content-Type:
-      - application/json
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_contents_listing.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "contents_listing_dev", "type": "BRANCH"}'
+    body: '{"name": "contents_listing_dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -132,12 +132,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_contents_listing", "snapshotId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents":
-      null, "key": {"elements": ["this", "is", "iceberg", "foo"]}, "type": "PUT"}],
-      "commitMeta": {"authorTime": null, "properties": null, "committer": null, "message":
-      "test message", "hash": null, "author": "nessie test", "signedOffBy": null,
-      "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_contents_listing", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["this", "is", "iceberg", "foo"]}, "expectedContents": null,
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -156,7 +156,7 @@ interactions:
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"07ef3e167d74d6a19b8dd9eef4ec9066bee279eecc50569ede7342ed1e9383ef\"\n}"
+        \ \"hash\" : \"8f68065ae540c95e58b8b1eca91c4a10a7db3146ff3ad20117861aa93edcc8c9\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -183,7 +183,7 @@ interactions:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n  \"hash\"
-        : \"07ef3e167d74d6a19b8dd9eef4ec9066bee279eecc50569ede7342ed1e9383ef\"\n}
+        : \"8f68065ae540c95e58b8b1eca91c4a10a7db3146ff3ad20117861aa93edcc8c9\"\n}
         ]"
     headers:
       Content-Length:
@@ -220,12 +220,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "uuid2", "metadataLocationHistory":
-      ["asd"], "lastCheckpoint": "x", "checkpointLocationHistory": ["def"], "type":
-      "DELTA_LAKE_TABLE"}, "expectedContents": null, "key": {"elements": ["this",
-      "is", "delta", "bar"]}, "type": "PUT"}], "commitMeta": {"authorTime": null,
-      "properties": null, "committer": null, "message": "test message", "hash": null,
-      "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"checkpointLocationHistory":
+      ["def"], "lastCheckpoint": "x", "metadataLocationHistory": ["asd"], "id": "uuid2",
+      "type": "DELTA_LAKE_TABLE"}, "key": {"elements": ["this", "is", "delta", "bar"]},
+      "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -240,11 +240,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=07ef3e167d74d6a19b8dd9eef4ec9066bee279eecc50569ede7342ed1e9383ef
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=8f68065ae540c95e58b8b1eca91c4a10a7db3146ff3ad20117861aa93edcc8c9
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"2b996ea5cd1da4145bfa5908ce0fdc08b7e9b2c3010af2dd715d5dc719988489\"\n}"
+        \ \"hash\" : \"8582d7b2991dabfcd2de3e01e55ad779fe92af5d79dc721e93bc071e4aafcd2f\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -271,7 +271,7 @@ interactions:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
         \ \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n  \"hash\"
-        : \"2b996ea5cd1da4145bfa5908ce0fdc08b7e9b2c3010af2dd715d5dc719988489\"\n}
+        : \"8582d7b2991dabfcd2de3e01e55ad779fe92af5d79dc721e93bc071e4aafcd2f\"\n}
         ]"
     headers:
       Content-Length:
@@ -308,11 +308,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "uuid3", "sqlText": "SELECT * FROM
-      foo", "dialect": "SPARK", "type": "VIEW"}, "expectedContents": null, "key":
-      {"elements": ["this", "is", "sql", "baz"]}, "type": "PUT"}], "commitMeta": {"authorTime":
-      null, "properties": null, "committer": null, "message": "test message", "hash":
-      null, "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"dialect": "SPARK",
+      "id": "uuid3", "sqlText": "SELECT * FROM foo", "type": "VIEW"}, "key": {"elements":
+      ["this", "is", "sql", "baz"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -327,11 +327,11 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=2b996ea5cd1da4145bfa5908ce0fdc08b7e9b2c3010af2dd715d5dc719988489
+    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev/commit?expectedHash=8582d7b2991dabfcd2de3e01e55ad779fe92af5d79dc721e93bc071e4aafcd2f
   response:
     body:
       string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"0ab87b72e7c37ae6dadf2c7a0f2aa1cc2546c0da1cf433982b24961306700e84\"\n}"
+        \ \"hash\" : \"9de483e7f5987cabcb091f7ac695de043b7fb43633fa8018eedd403eb9d33d96\"\n}"
     headers:
       Content-Length:
       - '137'
@@ -552,51 +552,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/contents_listing_dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"contents_listing_dev\",\n
-        \ \"hash\" : \"0ab87b72e7c37ae6dadf2c7a0f2aa1cc2546c0da1cf433982b24961306700e84\"\n}"
-    headers:
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/contents_listing_dev?expectedHash=0ab87b72e7c37ae6dadf2c7a0f2aa1cc2546c0da1cf433982b24961306700e84
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_log.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_log.yaml
@@ -100,11 +100,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_log", "snapshotId": 42, "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents": null, "key": {"elements":
-      ["log", "foo", "bar"]}, "type": "PUT"}], "commitMeta": {"authorTime": null,
-      "properties": null, "committer": null, "message": "test message", "hash": null,
-      "author": "nessie_user1", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie_user1", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_log", "type": "ICEBERG_TABLE"}, "key":
+      {"elements": ["log", "foo", "bar"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -122,7 +122,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -146,7 +146,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -195,7 +195,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -220,10 +220,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        [ {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -248,7 +248,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -269,14 +269,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?endHash=0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        [ {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -301,7 +301,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -362,10 +362,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"operations": [{"key": {"elements": ["log", "foo", "bar"]}, "type": "DELETE"}],
-      "commitMeta": {"authorTime": null, "properties": null, "committer": null, "message":
-      "delete_message", "hash": null, "author": "nessie_user2", "signedOffBy": null,
-      "commitTime": null}}'
+    body: '{"commitMeta": {"message": "delete_message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie_user2", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"key": {"elements": ["log", "foo",
+      "bar"]}, "type": "DELETE"}]}'
     headers:
       Accept:
       - '*/*'
@@ -380,10 +380,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488
+    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -407,7 +407,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -431,11 +431,11 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/main/log?max=1
   response:
     body:
-      string: "{\n  \"hasMore\" : true,\n  \"token\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
-        \ \"operations\" : [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+      string: "{\n  \"hasMore\" : true,\n  \"token\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
+        \ \"operations\" : [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -460,7 +460,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -485,14 +485,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -517,7 +517,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -538,14 +538,14 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7&endHash=4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488
+    uri: http://localhost:19120/api/v1/trees/tree/main/log?startHash=d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89&endHash=0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        [ {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -570,7 +570,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -595,14 +595,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -627,7 +627,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -652,10 +652,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        [ {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -680,7 +680,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -705,10 +705,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -733,7 +733,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -758,14 +758,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -790,7 +790,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -815,14 +815,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -847,7 +847,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -872,10 +872,10 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -900,7 +900,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -925,14 +925,14 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\",\n
+        [ {\n    \"hash\" : \"d04066d3a9ea79a1a2b298f8dba9e02d018cad4b646ba2e317d5e963fed8cd89\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user2\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.291590Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.291590Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"4aecc077002ac529605447c7c150ffc5be5aa7d655f70f5504def0edb47ee488\",\n
+        : null,\n    \"message\" : \"delete_message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.674072Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.674072Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"0a3d4baaba340b5cf66f3e10fdd78e849b430732a5682ef59e036108a426301e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie_user1\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:09.178152Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:09.178152Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:01.541616Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:01.541616Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -942,83 +942,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Named reference 'main' already exists.\",\n  \"status\"
-        : 409,\n  \"reason\" : \"Conflict\",\n  \"serverStackTrace\" : null\n}"
-    headers:
-      Content-Length:
-      - '130'
-      Content-Type:
-      - application/json
-    status:
-      code: 409
-      message: Conflict
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: PUT
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=73f1c93dc045ae165582983bcabc1e6bde9eb646316b7547b61fc36229e14dd7
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_merge.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_merge.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,11 +130,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_merge", "snapshotId": 42, "metadataLocation":
-      "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents": null, "key": {"elements":
-      ["merge", "foo", "bar"]}, "type": "PUT"}], "commitMeta": {"authorTime": null,
-      "properties": null, "committer": null, "message": "test message", "hash": null,
-      "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_merge", "type": "ICEBERG_TABLE"}, "key":
+      {"elements": ["merge", "foo", "bar"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -152,7 +152,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"452850d8a15e4c76933af612b25acc39e600718a4d4fbeb753c28ebe606c7aa7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -178,7 +178,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"452850d8a15e4c76933af612b25acc39e600718a4d4fbeb753c28ebe606c7aa7\"\n}
         ]"
     headers:
       Content-Length:
@@ -227,7 +227,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree/dev
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"452850d8a15e4c76933af612b25acc39e600718a4d4fbeb753c28ebe606c7aa7\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -237,7 +237,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fromRefName": "dev", "fromHash": "2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1"}'
+    body: '{"fromRefName": "dev", "fromHash": "452850d8a15e4c76933af612b25acc39e600718a4d4fbeb753c28ebe606c7aa7"}'
     headers:
       Accept:
       - '*/*'
@@ -276,242 +276,12 @@ interactions:
   response:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
-        \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}
+        \"452850d8a15e4c76933af612b25acc39e600718a4d4fbeb753c28ebe606c7aa7\"\n}, {\n
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"452850d8a15e4c76933af612b25acc39e600718a4d4fbeb753c28ebe606c7aa7\"\n}
         ]"
     headers:
       Content-Length:
       - '247'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main/log
-  response:
-    body:
-      string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1\",\n
-        \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.607527Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.607527Z\",\n    \"properties\"
-        : { }\n  } ]\n}"
-    headers:
-      Content-Length:
-      - '383'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/merge.foo.bar?ref=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"ICEBERG_TABLE\",\n  \"id\" : \"test_merge\",\n  \"metadataLocation\"
-        : \"/a/b/c\",\n  \"snapshotId\" : 42\n}"
-    headers:
-      Content-Length:
-      - '107'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"operations": [{"key": {"elements": ["merge", "foo", "bar"]}, "type":
-      "DELETE"}], "commitMeta": {"authorTime": null, "properties": null, "committer":
-      null, "message": "delete_message", "hash": null, "author": null, "signedOffBy":
-      null, "commitTime": null}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '257'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=2f5224a9b30a9f46c5913203c6c08117c8d0f0a617b1b8246bc719057d3b3ed1
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"f2b685ac5a084eec1af9734ca901ce97ad5ef78dbfe81abfe352ff16d731bccb\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"f2b685ac5a084eec1af9734ca901ce97ad5ef78dbfe81abfe352ff16d731bccb\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=f2b685ac5a084eec1af9734ca901ce97ad5ef78dbfe81abfe352ff16d731bccb
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
       Content-Type:
       - application/json
     status:

--- a/python/tests/cassettes/test_nessie_cli/test_tag.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_tag.yaml
@@ -49,8 +49,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev-tag", "type": "TAG"}'
+    body: '{"name": "dev-tag", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -129,8 +129,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "etl-tag", "type": "TAG"}'
+    body: '{"name": "etl-tag", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -351,8 +351,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "v1.0", "type": "TAG"}'
+    body: '{"name": "v1.0", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "TAG"}'
     headers:
       Accept:
       - '*/*'
@@ -433,50 +433,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/v1.0
-  response:
-    body:
-      string: "{\n  \"type\" : \"TAG\",\n  \"name\" : \"v1.0\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '118'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/tag/v1.0?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
 version: 1

--- a/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
+++ b/python/tests/cassettes/test_nessie_cli/test_transplant.yaml
@@ -48,8 +48,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "dev", "type": "BRANCH"}'
+    body: '{"name": "dev", "hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
+      "type": "BRANCH"}'
     headers:
       Accept:
       - '*/*'
@@ -130,12 +130,12 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_transplant_1", "snapshotId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents":
-      null, "key": {"elements": ["transplant", "foo", "bar"]}, "type": "PUT"}], "commitMeta":
-      {"authorTime": null, "properties": null, "committer": null, "message": "test
-      message", "hash": null, "author": "nessie test", "signedOffBy": null, "commitTime":
-      null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_transplant_1", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["transplant", "foo", "bar"]}, "expectedContents": null,
+      "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -153,7 +153,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9070cfe17aec5a4f53df90737ebd21b3ba0fed66a1e013a754b08564e26f4458\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d366b3e252d014d8dc614ea809aeb78e84785a678af1af069f43408bd35120fd\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -179,7 +179,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"9070cfe17aec5a4f53df90737ebd21b3ba0fed66a1e013a754b08564e26f4458\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"d366b3e252d014d8dc614ea809aeb78e84785a678af1af069f43408bd35120fd\"\n}
         ]"
     headers:
       Content-Length:
@@ -216,11 +216,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_transplant_2", "snapshotId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents":
-      null, "key": {"elements": ["bar", "bar"]}, "type": "PUT"}], "commitMeta": {"authorTime":
-      null, "properties": null, "committer": null, "message": "test message", "hash":
-      null, "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_transplant_2", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["bar", "bar"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -235,10 +235,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=9070cfe17aec5a4f53df90737ebd21b3ba0fed66a1e013a754b08564e26f4458
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=d366b3e252d014d8dc614ea809aeb78e84785a678af1af069f43408bd35120fd
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"432823def9af070795615a6d906b485572421c1561aac7549614bf1857d6370e\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4374167502cfb542ad78cbdbc28279f8cf41c551df7e273c5ee2d9fb8b0be33f\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -264,7 +264,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"432823def9af070795615a6d906b485572421c1561aac7549614bf1857d6370e\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"4374167502cfb542ad78cbdbc28279f8cf41c551df7e273c5ee2d9fb8b0be33f\"\n}
         ]"
     headers:
       Content-Length:
@@ -301,11 +301,11 @@ interactions:
       code: 404
       message: Not Found
 - request:
-    body: '{"operations": [{"contents": {"id": "test_transplant_3", "snapshotId":
-      42, "metadataLocation": "/a/b/c", "type": "ICEBERG_TABLE"}, "expectedContents":
-      null, "key": {"elements": ["foo", "baz"]}, "type": "PUT"}], "commitMeta": {"authorTime":
-      null, "properties": null, "committer": null, "message": "test message", "hash":
-      null, "author": "nessie test", "signedOffBy": null, "commitTime": null}}'
+    body: '{"commitMeta": {"message": "test message", "properties": null, "hash":
+      null, "committer": null, "authorTime": null, "author": "nessie test", "commitTime":
+      null, "signedOffBy": null}, "operations": [{"contents": {"metadataLocation":
+      "/a/b/c", "snapshotId": 42, "id": "test_transplant_3", "type": "ICEBERG_TABLE"},
+      "key": {"elements": ["foo", "baz"]}, "expectedContents": null, "type": "PUT"}]}'
     headers:
       Accept:
       - '*/*'
@@ -320,10 +320,10 @@ interactions:
       User-Agent:
       - python-requests/2.26.0
     method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=432823def9af070795615a6d906b485572421c1561aac7549614bf1857d6370e
+    uri: http://localhost:19120/api/v1/trees/branch/dev/commit?expectedHash=4374167502cfb542ad78cbdbc28279f8cf41c551df7e273c5ee2d9fb8b0be33f
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"45ed25ab6a3f5eee253241cee1be219b53ac161e4e6a8869c00c7e4c9149206a\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e61f8bbf3f1114ce5ff1e6f144d23b2190e7921037db2ecc43e2f5b54727302\"\n}"
     headers:
       Content-Length:
       - '120'
@@ -349,7 +349,7 @@ interactions:
     body:
       string: "[ {\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" :
         \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}, {\n
-        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"45ed25ab6a3f5eee253241cee1be219b53ac161e4e6a8869c00c7e4c9149206a\"\n}
+        \ \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"2e61f8bbf3f1114ce5ff1e6f144d23b2190e7921037db2ecc43e2f5b54727302\"\n}
         ]"
     headers:
       Content-Length:
@@ -375,18 +375,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"45ed25ab6a3f5eee253241cee1be219b53ac161e4e6a8869c00c7e4c9149206a\",\n
+        [ {\n    \"hash\" : \"2e61f8bbf3f1114ce5ff1e6f144d23b2190e7921037db2ecc43e2f5b54727302\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.890549Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.890549Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"432823def9af070795615a6d906b485572421c1561aac7549614bf1857d6370e\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:03.393629Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:03.393629Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"4374167502cfb542ad78cbdbc28279f8cf41c551df7e273c5ee2d9fb8b0be33f\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.851865Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.851865Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"9070cfe17aec5a4f53df90737ebd21b3ba0fed66a1e013a754b08564e26f4458\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:03.355270Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:03.355270Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"d366b3e252d014d8dc614ea809aeb78e84785a678af1af069f43408bd35120fd\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.814581Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.814581Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:03.320793Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:03.320793Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
@@ -421,9 +421,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"hashesToTransplant": ["432823def9af070795615a6d906b485572421c1561aac7549614bf1857d6370e",
-      "45ed25ab6a3f5eee253241cee1be219b53ac161e4e6a8869c00c7e4c9149206a"], "fromRefName":
-      "dev"}'
+    body: '{"fromRefName": "dev", "hashesToTransplant": ["4374167502cfb542ad78cbdbc28279f8cf41c551df7e273c5ee2d9fb8b0be33f",
+      "2e61f8bbf3f1114ce5ff1e6f144d23b2190e7921037db2ecc43e2f5b54727302"]}'
     headers:
       Accept:
       - '*/*'
@@ -461,7 +460,7 @@ interactions:
     uri: http://localhost:19120/api/v1/trees/tree
   response:
     body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"4ba13772c2fc80c830c00896f490eeb768f508241dd724d661289715b600e087\"\n}"
+      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"69a494011197087c77f2cb5a553b6d5261511e833fe9182dee919f83d2da724e\"\n}"
     headers:
       Content-Length:
       - '121'
@@ -486,196 +485,18 @@ interactions:
   response:
     body:
       string: "{\n  \"hasMore\" : false,\n  \"token\" : null,\n  \"operations\" :
-        [ {\n    \"hash\" : \"4ba13772c2fc80c830c00896f490eeb768f508241dd724d661289715b600e087\",\n
+        [ {\n    \"hash\" : \"69a494011197087c77f2cb5a553b6d5261511e833fe9182dee919f83d2da724e\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.890549Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.890549Z\",\n    \"properties\"
-        : { }\n  }, {\n    \"hash\" : \"2dd251a02e337545fb81c661f511c1294c79546cbe706c763dfaf1e02b6af65f\",\n
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:03.393629Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:03.393629Z\",\n    \"properties\"
+        : { }\n  }, {\n    \"hash\" : \"84ba800c1ded7d63bd9c7371693f753766900e2200dd59c743acab62321ccc10\",\n
         \   \"committer\" : \"\",\n    \"author\" : \"nessie test\",\n    \"signedOffBy\"
-        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T15:46:10.851865Z\",\n
-        \   \"authorTime\" : \"2021-10-15T15:46:10.851865Z\",\n    \"properties\"
+        : null,\n    \"message\" : \"test message\",\n    \"commitTime\" : \"2021-10-15T16:50:03.355270Z\",\n
+        \   \"authorTime\" : \"2021-10-15T16:50:03.355270Z\",\n    \"properties\"
         : { }\n  } ]\n}"
     headers:
       Content-Length:
       - '704'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/contents/transplant.foo.bar?ref=main
-  response:
-    body:
-      string: "{\n  \"message\" : \"Requested contents do not exist for specified
-        reference.\",\n  \"status\" : 404,\n  \"reason\" : \"Not Found\",\n  \"serverStackTrace\"
-        : null\n}"
-    headers:
-      Content-Length:
-      - '149'
-      Content-Type:
-      - application/json
-    status:
-      code: 404
-      message: Not Found
-- request:
-    body: '{"operations": [{"key": {"elements": ["transplant", "foo", "bar"]}, "type":
-      "DELETE"}], "commitMeta": {"authorTime": null, "properties": null, "committer":
-      null, "message": "delete_message", "hash": null, "author": null, "signedOffBy":
-      null, "commitTime": null}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '262'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/branch/main/commit?expectedHash=4ba13772c2fc80c830c00896f490eeb768f508241dd724d661289715b600e087
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"23ce2f71cfc449b58b2f3c0dcff06b21edfeadc8199a48dce0d93268359984f7\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/dev
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"dev\",\n  \"hash\" : \"45ed25ab6a3f5eee253241cee1be219b53ac161e4e6a8869c00c7e4c9149206a\"\n}"
-    headers:
-      Content-Length:
-      - '120'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/dev?expectedHash=45ed25ab6a3f5eee253241cee1be219b53ac161e4e6a8869c00c7e4c9149206a
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: http://localhost:19120/api/v1/trees/tree/main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"23ce2f71cfc449b58b2f3c0dcff06b21edfeadc8199a48dce0d93268359984f7\"\n}"
-    headers:
-      Content-Length:
-      - '121'
-      Content-Type:
-      - application/json
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: DELETE
-    uri: http://localhost:19120/api/v1/trees/branch/main?expectedHash=23ce2f71cfc449b58b2f3c0dcff06b21edfeadc8199a48dce0d93268359984f7
-  response:
-    body:
-      string: ''
-    headers: {}
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"hash": "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d",
-      "name": "main", "type": "BRANCH"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '110'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: http://localhost:19120/api/v1/trees/tree?sourceRefName=main
-  response:
-    body:
-      string: "{\n  \"type\" : \"BRANCH\",\n  \"name\" : \"main\",\n  \"hash\" : \"2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d\"\n}"
-    headers:
-      Content-Length:
-      - '121'
       Content-Type:
       - application/json
     status:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,10 +4,25 @@
 import os
 import shutil
 import tempfile
+from typing import List
+from typing import Optional
 
 import pytest
+from _pytest.fixtures import FixtureRequest
+from assertpy import assert_that
+from click.testing import CliRunner
+from click.testing import Result
 from pytest import Session
+from vcr.request import Request
 
+from pynessie import cli
+from pynessie.model import ReferenceSchema
+
+# Per-test Nessie config directly
+nessie_config_dir: str
+
+# Helper variable to control VCR recording in test fixtures
+nessie_cleanup: bool = False
 
 def pytest_configure(config):  # noqa
     """Configure pytest."""
@@ -16,11 +31,91 @@ def pytest_configure(config):  # noqa
 
 def pytest_sessionstart(session: "Session") -> None:
     """Setup a fresh temporary config directory for tests."""
-    pytest.nessie_config_dir = tempfile.mkdtemp() + "/"
+    global nessie_config_dir
+    nessie_config_dir = tempfile.mkdtemp() + "/"
     # Instruct Confuse to keep Nessie config file in the temp location:
-    os.environ["NESSIEDIR"] = pytest.nessie_config_dir
+    os.environ["NESSIEDIR"] = nessie_config_dir
 
 
 def pytest_sessionfinish(session: "Session", exitstatus: int) -> None:
     """Remove temporary config directory."""
-    shutil.rmtree(pytest.nessie_config_dir)
+    global nessie_config_dir
+    shutil.rmtree(nessie_config_dir)
+
+
+def _run(args: List[str], input: Optional[str] = None, ret_val: int = 0) -> Result:
+    result = CliRunner().invoke(cli.cli, args, input=input)
+    if result.exit_code != ret_val:
+        print(result.output)
+        print(result)
+    assert_that(result.exit_code).is_equal_to(ret_val)
+    return result
+
+
+def _cli(args: List[str], input: Optional[str] = None, ret_val: int = 0) -> str:
+    return _run(args, input, ret_val).output
+
+
+def reset_nessie_server_state() -> None:
+    """Resets the Nessie Server to an initial, clean state for testing."""
+    # Delete all branches
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
+    for branch in branches:
+        _cli(["branch", "-d", branch.name])
+
+    # Delete all tags
+    tags = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
+    for tag in tags:
+        _cli(["tag", "-d", tag.name])
+
+    # Note: This hash should match the java constant AbstractDatabaseAdapter.NO_ANCESTOR
+    no_ancestor_hash = "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
+
+    # Re-create the main branch from the "root" (a.k.a. no ancestor) hash
+    _cli(["branch", "--force", "-o", no_ancestor_hash, "main", "main"])
+
+    # Verify the re-created main branch
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
+    assert_that(branches).is_length(1)
+    assert_that(branches[0].name).is_equal_to("main")
+    assert_that(branches[0].hash_).is_equal_to(no_ancestor_hash)
+
+
+def before_record_cb(request: Request) -> Optional[Request]:
+    """VCR callback that instructs it to not record our "cleanup" requests."""
+    if nessie_cleanup:
+        return None
+    return request
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> dict:
+    """VCR config that adds a custom before_record_request callback."""
+    pytest.nessie_cleanup = False
+    return {
+        "before_record_request": before_record_cb,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_nessie_session_marker(request: "FixtureRequest", record_mode: str) -> None:
+    """This pytest fixture is invoked for all test methods and cleans up the Nessie Server state.
+
+    :param request Request object provided by the pytest framework
+    :param record_mode Recording mode provided by the VCR plugin
+    """
+    # Cleaning the Nessie Server state is meaningful only when we are recording,
+    # i.e. when the tests are running against a real server, not against VCR cassettes.
+    # Consequently, when the tests will run against VCR cassettes, the pre-recorded
+    # responses will simulate a "clean" server.
+    if record_mode is None or record_mode == "none":
+        return
+
+    # Clean the server state for tests that have the @pytest.mark.clean_nessie_session annotation
+    if request.node.get_closest_marker("vcr"):
+        global nessie_cleanup
+        try:
+            nessie_cleanup = True
+            reset_nessie_server_state()
+        finally:
+            nessie_cleanup = False

--- a/python/tests/test_nessie_cli.py
+++ b/python/tests/test_nessie_cli.py
@@ -4,18 +4,13 @@
 import itertools
 import os
 from pathlib import Path
-from typing import List
-from typing import Optional
 
 import confuse
 import pytest
 import simplejson
 from assertpy import assert_that
-from click.testing import CliRunner
-from click.testing import Result
 
 from pynessie import __version__
-from pynessie import cli
 from pynessie.model import Branch
 from pynessie.model import Contents
 from pynessie.model import ContentsSchema
@@ -24,28 +19,17 @@ from pynessie.model import EntrySchema
 from pynessie.model import IcebergTable
 from pynessie.model import ReferenceSchema
 from pynessie.model import SqlView
-
-
-def _run(runner: CliRunner, args: List[str], input: Optional[str] = None, ret_val: int = 0) -> Result:
-    result = runner.invoke(cli.cli, args, input=input)
-    if result.exit_code != ret_val:
-        print(result.output)
-    assert result.exit_code == ret_val
-    return result
+from .conftest import _cli
+from .conftest import _run
 
 
 @pytest.mark.vcr
 def test_command_line_interface() -> None:
     """Test the CLI."""
-    runner = CliRunner()
-    result = _run(runner, list())
-    assert "Usage: cli" in result.output
-    help_result = _run(runner, ["--help"])
-    assert "Usage: cli" in help_result.output
-    help_result = _run(runner, ["--version"])
-    assert __version__ in help_result.output
-    help_result = _run(runner, ["--json", "branch", "-l"])
-    references = ReferenceSchema().loads(help_result.output, many=True)
+    assert "Usage: cli" in _cli(list())
+    assert "Usage: cli" in _cli(["--help"])
+    assert __version__ in _cli(["--version"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch", "-l"]), many=True)
     assert len(references) == 1
     assert references[0].name == "main"
     assert isinstance(references[0], Branch)
@@ -53,41 +37,32 @@ def test_command_line_interface() -> None:
 
 def test_config_options() -> None:
     """Ensure config cli option is consistent."""
-    runner = CliRunner()
-    result = _run(runner, ["config"])
-    assert "Usage: cli" in result.output
+    assert "Usage: cli" in _cli(["config"])
     vars = ["--add x", "--get x", "--list", "--unset x"]
     for i in itertools.permutations(vars, 2):
-        result = _run(runner, ["config"] + [*i[0].split(" "), *i[1].split(" ")], ret_val=2)
-        assert "Error: Illegal usage: " in result.output
+        assert "Error: Illegal usage: " in _cli(["config"] + [*i[0].split(" "), *i[1].split(" ")], ret_val=2)
 
-    _run(runner, ["config", "x", "--add", "x"])
+    _cli(["config", "x", "--add", "x"])
 
 
 def test_set_unset() -> None:
     """Test config set/unset/list."""
-    runner = CliRunner()
-    _run(runner, ["config", "--add", "test.data", "123", "--type", "int"])
-    result = _run(runner, ["config", "test.data", "--type", "int"])
-    assert result.output == "123\n"
-    _run(runner, ["config", "--unset", "test.data"])
-    result = _run(runner, ["config", "--list"])
-    assert "123" not in result.output
+    _cli(["config", "--add", "test.data", "123", "--type", "int"])
+    assert _cli(["config", "test.data", "--type", "int"]) == "123\n"
+    _cli(["config", "--unset", "test.data"])
+    assert "123" not in _cli(["config", "--list"])
 
 
 @pytest.mark.vcr
 def test_remote() -> None:
     """Test setting and viewing remote."""
-    runner = CliRunner()
-    _run(runner, ["remote", "add", "http://test.url"])
-    _run(runner, ["remote", "add", "http://localhost:19120/api/v1"])
-    result = _run(runner, ["--json", "remote", "show"])
-    assert "main" in result.output
-    _run(runner, ["remote", "set-head", "dev"])
-    result = _run(runner, ["config", "default_branch"])
-    assert result.output == "dev\n"
-    _run(runner, ["remote", "set-head", "dev", "-d"])
-    result = _run(runner, ["config", "default_branch"], ret_val=1)
+    _cli(["remote", "add", "http://test.url"])
+    _cli(["remote", "add", "http://localhost:19120/api/v1"])
+    assert "main" in _cli(["--json", "remote", "show"])
+    _cli(["remote", "set-head", "dev"])
+    assert _cli(["config", "default_branch"]) == "dev\n"
+    _cli(["remote", "set-head", "dev", "-d"])
+    result = _run(["config", "default_branch"], ret_val=1)
     assert result.output == ""
     assert isinstance(result.exception, confuse.exceptions.ConfigTypeError)
 
@@ -98,49 +73,33 @@ def _new_table(table_id: str) -> IcebergTable:
 
 def _make_commit(
     key: str, table: Contents, branch: str, head_hash: str = None, message: str = "test message", author: str = "nessie test"
-) -> IcebergTable:
+) -> None:
     if not head_hash:
-        result = _run(CliRunner(), ["--json", "branch"])
-        refs = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+        refs = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)}
         head_hash = refs[branch]
-    _run(
-        CliRunner(),
+    _cli(
         ["contents", "--set", "--stdin", key, "--ref", branch, "-m", message, "-c", head_hash, "--author", author],
         input=ContentsSchema().dumps(table),
     )
 
 
-def _reset_main() -> None:
-    # Note: This hash should match the java constant AbstractDatabaseAdapter.NO_ANCESTOR
-    no_ancestor_hash = "2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d"
-    # Re-create branch main from the root hash (assuming in-memory store)
-    _run(CliRunner(), ["branch", "--force", "-o", no_ancestor_hash, "main", "main"])
-
-
 @pytest.mark.vcr
 def test_log() -> None:
     """Test log and log filtering."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 0
     table = _new_table("test_log")
     _make_commit("log.foo.bar", table, "main", author="nessie_user1")
-    result = _run(runner, ["--json", "contents", "log.foo.bar"])
-    tables = ContentsSchema().loads(result.output, many=True)
+    tables = ContentsSchema().loads(_cli(["--json", "contents", "log.foo.bar"]), many=True)
     assert len(tables) == 1
     assert tables[0] == table
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log", logs[0]["hash"]])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", logs[0]["hash"]]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "contents", "--list"])
-    entries = EntrySchema().loads(result.output, many=True)
+    entries = EntrySchema().loads(_cli(["--json", "contents", "--list"]), many=True)
     assert len(entries) == 1
-    _run(
-        runner,
+    _cli(
         [
             "--json",
             "contents",
@@ -156,111 +115,83 @@ def test_log() -> None:
             "nessie_user2",
         ],
     )
-    result = _run(runner, ["--json", "log", "-n", 1])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "-n", 1]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2
-    result = _run(runner, ["--json", "log", "{}..{}".format(logs[0]["hash"], logs[1]["hash"])])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "{}..{}".format(logs[0]["hash"], logs[1]["hash"])]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2
-    result = _run(runner, ["--json", "log", "--author", "nessie_user1"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--author", "nessie_user1"]))
     assert len(logs) == 1
     assert_that(logs[0]["author"]).is_equal_to("nessie_user1")
-    result = _run(runner, ["--json", "log", "--author", "nessie_user2"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--author", "nessie_user2"]))
     assert len(logs) == 1
     assert_that(logs[0]["author"]).is_equal_to("nessie_user2")
-    result = _run(runner, ["--json", "log", "--author", "nessie_user2", "--author", "nessie_user1"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--author", "nessie_user2", "--author", "nessie_user1"]))
     assert len(logs) == 2
     # the committer is set on the server-side and is empty if we're not logged
     # in when performing a commit
-    result = _run(runner, ["--json", "log", "--committer", ""])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--committer", ""]))
     assert len(logs) == 2
-    result = _run(runner, ["--json", "log", "--query", "commit.author == 'nessie_user2' || commit.author == 'non_existing'"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--query", "commit.author == 'nessie_user2' || commit.author == 'non_existing'"]))
     assert len(logs) == 1
-    result = _run(runner, ["--json", "log", "--after", "2001-01-01T00:00:00+00:00", "--before", "2999-12-30T23:00:00+00:00"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--after", "2001-01-01T00:00:00+00:00", "--before", "2999-12-30T23:00:00+00:00"]))
     assert len(logs) == 2
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_branch() -> None:
     """Test create and assign refs."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 1
-    _run(runner, ["branch", "dev"])
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["branch", "dev"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 2
-    _run(runner, ["branch", "etl", "main"])
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["branch", "etl", "main"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 3
-    _run(runner, ["branch", "-d", "etl"])
-    _run(runner, ["branch", "-d", "dev"])
-    result = _run(runner, ["--json", "branch"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["branch", "-d", "etl"])
+    _cli(["branch", "-d", "dev"])
+    references = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     assert len(references) == 1
 
 
 @pytest.mark.vcr
 def test_tag() -> None:
     """Test create and assign refs."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 0
-    _run(runner, ["tag", "dev-tag", "main"])
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["tag", "dev-tag", "main"])
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 1
-    _run(runner, ["tag", "etl-tag", "main"])
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["tag", "etl-tag", "main"])
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 2
-    _run(runner, ["tag", "-d", "etl-tag"])
-    _run(runner, ["tag", "-d", "dev-tag"])
-    result = _run(runner, ["--json", "tag"])
-    references = ReferenceSchema().loads(result.output, many=True)
+    _cli(["tag", "-d", "etl-tag"])
+    _cli(["tag", "-d", "dev-tag"])
+    references = ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)
     assert len(references) == 0
-    _run(runner, ["tag", "v1.0"])
-    result = _run(runner, ["--json", "tag"])
-    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
-    result = _run(runner, ["--json", "branch"])
-    branches = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+    _cli(["tag", "v1.0"])
+    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)}
+    branches = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)}
     assert tags["v1.0"] == branches["main"]
-    _run(runner, ["tag", "-d", "v1.0"])
 
 
 @pytest.mark.vcr
 def test_commit_with_expected_state() -> None:
     """Test making a commit with some expected Contents, i.e. IcebergTable."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("commit.expected.contents", _new_table("test_expected_contents"), "dev", message="commit 1")
     # the second commit will use the Contents of the first one as "expected contents"
     _make_commit("commit.expected.contents", _new_table("test_expected_contents"), "dev", message="commit 2")
-    _run(runner, ["branch", "-d", "dev"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_commit_no_expected_state() -> None:
     """Test making two commit without any expected Contents, i.e. using DeltaLakeTable."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     table1 = DeltaLakeTable(
         id="test_commit_no_expected_state", metadata_location_history=["asd111"], checkpoint_location_history=["def"], last_checkpoint="x"
     )
@@ -270,95 +201,66 @@ def test_commit_no_expected_state() -> None:
     )
     # the second commit will set new contents without the "expected contents" parameter due to using a DeltaLakeTable
     _make_commit("commit.expected.contents", table2, "dev", message="commit 2")
-    _run(runner, ["branch", "-d", "dev"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_assign() -> None:
     """Test assign operation."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("assign.foo.bar", _new_table("test_assign"), "dev")
-    _run(runner, ["branch", "main", "dev", "--force"])
-    result = _run(runner, ["--json", "branch"])
-    branches = ReferenceSchema().loads(result.output, many=True)
+    _run(["branch", "main", "dev", "--force"])
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
     assert refs["main"] == refs["dev"]
-    _run(runner, ["tag", "v1.0", "main"])
-    result = _run(runner, ["--json", "tag"])
-    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+    _cli(["tag", "v1.0", "main"])
+    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)}
     assert tags["v1.0"] == refs["main"]
-    _run(runner, ["tag", "v1.0", "dev", "--force"])
-    result = _run(runner, ["--json", "tag"])
-    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(result.output, many=True)}
+    _cli(["tag", "v1.0", "dev", "--force"])
+    tags = {i.name: i.hash_ for i in ReferenceSchema().loads(_cli(["--json", "tag"]), many=True)}
     assert tags["v1.0"] == refs["dev"]
-    _run(runner, ["branch", "dev", "--delete"])
-    _run(runner, ["tag", "v1.0", "--delete"])
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
-    _run(runner, ["--json", "contents", "--delete", "assign.foo.bar", "--ref", "main", "-m", "delete_message", "-c", logs[0]["hash"]])
-    _run(runner, ["branch", "main", "--delete"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_merge() -> None:
     """Test merge operation."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("merge.foo.bar", _new_table("test_merge"), "dev")
-    refs = ReferenceSchema().loads(_run(runner, ["--json", "branch", "-l", "main"]).output, many=True)
+    refs = ReferenceSchema().loads(_cli(["--json", "branch", "-l", "main"]), many=True)
     main_hash = next(i.hash_ for i in refs if i.name == "main")
-    _run(runner, ["merge", "dev", "-c", main_hash])
-    result = _run(runner, ["--json", "branch"])
-    branches = ReferenceSchema().loads(result.output, many=True)
+    _cli(["merge", "dev", "-c", main_hash])
+    branches = ReferenceSchema().loads(_cli(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
     assert refs["main"] == refs["dev"]
-    _run(runner, ["branch", "dev", "--delete"])
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
-    _run(runner, ["--json", "contents", "--delete", "merge.foo.bar", "--ref", "main", "-m", "delete_message", "-c", logs[0]["hash"]])
-    _run(runner, ["branch", "main", "--delete"])
-    _reset_main()
 
 
 @pytest.mark.vcr
 def test_transplant() -> None:
     """Test transplant operation."""
-    runner = CliRunner()
-    _run(runner, ["branch", "dev"])
+    _cli(["branch", "dev"])
     _make_commit("transplant.foo.bar", _new_table("test_transplant_1"), "dev")
     _make_commit("bar.bar", _new_table("test_transplant_2"), "dev")
     _make_commit("foo.baz", _new_table("test_transplant_3"), "dev")
-    refs = ReferenceSchema().loads(_run(runner, ["--json", "branch", "-l"]).output, many=True)
+    refs = ReferenceSchema().loads(_cli(["--json", "branch", "-l"]), many=True)
     main_hash = next(i.hash_ for i in refs if i.name == "main")
-    result = _run(runner, ["--json", "log", "--ref", "dev"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log", "--ref", "dev"]))
     first_hash = [i["hash"] for i in logs]
-    _run(runner, ["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
+    _cli(["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
 
-    result = _run(runner, ["--json", "log"])
-    logs = simplejson.loads(result.output)
+    logs = simplejson.loads(_cli(["--json", "log"]))
     assert len(logs) == 2  # two commits were transplanted into an empty `main`
-    _run(runner, ["--json", "contents", "--delete", "transplant.foo.bar", "--ref", "main", "-m", "delete_message", "-c", logs[0]["hash"]])
-    _run(runner, ["branch", "dev", "--delete"])
-    _run(runner, ["branch", "main", "--delete"])
-    _reset_main()
 
 
 @pytest.mark.doc
 def test_all_help_options() -> None:
     """Write out all help options to std out."""
-    runner = CliRunner()
     args = ["", "config", "branch", "tag", "remote", "log", "merge", "cherry-pick", "contents"]
 
     for i in args:
-        result = _run(runner, [x for x in [i] if x] + ["--help"])
+        result = _cli([x for x in [i] if x] + ["--help"])
         cwd = os.getcwd()
         with open(Path(Path(cwd), "docs", "{}.rst".format(i if i else "main")), "w") as f:
             f.write(".. code-block:: bash\n\n\t")
-            for line in result.output.split("\n"):
+            for line in result.split("\n"):
                 f.write(line + "\n\t")
             f.write("\n\n")
 
@@ -366,9 +268,8 @@ def test_all_help_options() -> None:
 @pytest.mark.vcr
 def test_contents_listing() -> None:
     """Test contents listing and filtering."""
-    runner = CliRunner()
     branch = "contents_listing_dev"
-    _run(runner, ["branch", branch])
+    _cli(["branch", branch])
 
     iceberg_table = IcebergTable(id="test_contents_listing", metadata_location="/a/b/c", snapshot_id=42)
     delta_lake_table = DeltaLakeTable(
@@ -380,47 +281,40 @@ def test_contents_listing() -> None:
     _make_commit("this.is.delta.bar", delta_lake_table, branch)
     _make_commit("this.is.sql.baz", sql_view, branch)
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "this.is.iceberg.foo"])
-    tables = ContentsSchema().loads(result.output, many=True)
+    tables = ContentsSchema().loads(_cli(["--json", "contents", "--ref", branch, "this.is.iceberg.foo"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0]).is_equal_to(iceberg_table)
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "this.is.delta.bar"])
-    tables = ContentsSchema().loads(result.output, many=True)
+    tables = ContentsSchema().loads(_cli(["--json", "contents", "--ref", branch, "this.is.delta.bar"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0]).is_equal_to(delta_lake_table)
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--type", "ICEBERG_TABLE"])
-    tables = EntrySchema().loads(result.output, many=True)
+    tables = EntrySchema().loads(_cli(["--json", "contents", "--ref", branch, "--list", "--type", "ICEBERG_TABLE"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("ICEBERG_TABLE")
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--type", "DELTA_LAKE_TABLE"])
-    tables = EntrySchema().loads(result.output, many=True)
+    tables = EntrySchema().loads(_cli(["--json", "contents", "--ref", branch, "--list", "--type", "DELTA_LAKE_TABLE"]), many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("DELTA_LAKE_TABLE")
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType == 'ICEBERG_TABLE'"])
-    tables = EntrySchema().loads(result.output, many=True)
+    result = _cli(["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType == 'ICEBERG_TABLE'"])
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("ICEBERG_TABLE")
 
-    result = _run(
-        runner,
-        ["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType in ['ICEBERG_TABLE', 'DELTA_LAKE_TABLE']"],
+    result = _cli(
+        ["--json", "contents", "--ref", branch, "--list", "--query", "entry.contentType in ['ICEBERG_TABLE', 'DELTA_LAKE_TABLE']"]
     )
-    tables = EntrySchema().loads(result.output, many=True)
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(2)
     assert_that(set(t.kind for t in tables)).is_equal_to({"DELTA_LAKE_TABLE", "ICEBERG_TABLE"})
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is.del')"])
-    tables = EntrySchema().loads(result.output, many=True)
+    result = _cli(["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is.del')"])
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(1)
     assert_that(tables[0].kind).is_equal_to("DELTA_LAKE_TABLE")
 
-    result = _run(runner, ["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is')"])
-    tables = EntrySchema().loads(result.output, many=True)
+    result = _cli(["--json", "contents", "--ref", branch, "--list", "--query", "entry.namespace.startsWith('this.is')"])
+    tables = EntrySchema().loads(result, many=True)
     assert_that(tables).is_length(3)
     assert_that(set(i.kind for i in tables)).is_equal_to({"ICEBERG_TABLE", "VIEW", "DELTA_LAKE_TABLE"})
-
-    _run(runner, ["branch", branch, "--delete"])

--- a/python/tests/test_nessie_cli_auth.py
+++ b/python/tests/test_nessie_cli_auth.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Authentication tests for Nessi CLI."""
 import pytest
-from click.testing import CliRunner
 
-from .test_nessie_cli import _run
+from .conftest import _cli
 
 
 @pytest.fixture(scope="module")
@@ -15,14 +14,11 @@ def vcr_config() -> dict:
 @pytest.mark.vcr
 def test_bearer_auth() -> None:
     """Test the "remote show" command with bearer authentication."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "--auth-token", "test_token_123", "remote", "show"])
-    assert "main" in result.output
+    assert "main" in _cli(["--json", "--auth-token", "test_token_123", "remote", "show"])
 
 
 @pytest.mark.vcr
 def test_bearer_auth_invalid() -> None:
     """Test any command with an invalid bearer authentication token."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "--auth-token", "invalid", "remote", "show"], ret_val=1)
-    assert "401 Client Error: Unauthorized" in result.output
+    result = _cli(["--json", "--auth-token", "invalid", "remote", "show"], ret_val=1)
+    assert "401 Client Error: Unauthorized" in result

--- a/python/tests/test_nessie_cli_error.py
+++ b/python/tests/test_nessie_cli_error.py
@@ -15,9 +15,8 @@
 #  limitations under the License.
 
 import pytest
-from click.testing import CliRunner
 
-from .test_nessie_cli import _run
+from .conftest import _cli
 
 
 # Note: tests in this file use custom VCR files for error server responses.
@@ -29,16 +28,14 @@ from .test_nessie_cli import _run
 @pytest.mark.vcr
 def test_server_error_html() -> None:
     """Test the handling of 500 responses with HTML payload (unexpected, but possible)."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "remote", "show"], ret_val=1)
-    assert "Internal Server Error" in result.output
-    assert "500" in result.output
+    result = _cli(["--json", "remote", "show"], ret_val=1)
+    assert "Internal Server Error" in result
+    assert "500" in result
 
 
 @pytest.mark.vcr
 def test_server_error_json() -> None:
     """Test the handling of 500 responses with JSON payload."""
-    runner = CliRunner()
-    result = _run(runner, ["--json", "remote", "show"], ret_val=1)
-    assert "Default branch isn't a branch" in result.output
-    assert "500" in result.output
+    result = _cli(["--json", "remote", "show"], ret_val=1)
+    assert "Default branch isn't a branch" in result
+    assert "500" in result


### PR DESCRIPTION
* Add pytest fixtures to clean test branches up in the Nessie
  server before VCR tests.

* Add utility method _cli(...) to automatically unwrap CLI output

* Move global helper variables from the `pytest` scope to local scope